### PR TITLE
fix: use crates-io-auth-action for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    environment: release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -76,9 +77,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master (2026-02-13)
         with:
           toolchain: stable
+      - name: Get crates.io token via trusted publishing
+        id: auth
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
       - run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ""
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   publish-release:
     needs: [release-please, publish-crate]


### PR DESCRIPTION
## Summary
- Replaces empty `CARGO_REGISTRY_TOKEN` with `rust-lang/crates-io-auth-action` (SHA-pinned) for OIDC token exchange
- Adds `environment: release` to match the trusted publisher config on crates.io
- Fixes the `publish-crate` job failure: "please provide a non-empty token"

## Test plan
- [ ] Merge and verify next release-please release publishes to crates.io successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)