### PR TITLE
chore: add Dependabot for Cargo + GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+
+updates:
+  # Rust dependencies — weekly check for security patches and version bumps.
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: friday
+    commit-message:
+      prefix: "chore(deps):"
+    labels:
+      - dependencies
+    open-pull-requests-limit: 5
+    groups:
+      rust-dependencies:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions — pinned to full SHA; Dependabot proposes SHA bumps.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: friday
+    commit-message:
+      prefix: "chore(ci):"
+    labels:
+      - ci
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        update-types:
+          - major
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

- Weekly digest PRs for Cargo dep bumps (minor/patch grouped into one PR)
- Weekly digest PRs for GitHub Actions SHA bumps (all grouped into one PR)
- Security advisories still get individual PRs for fast triage
- Matches the same Dependabot configuration used in memory-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)