### PR TITLE
feat: session lifecycle observability — builder API, max lifetime, close reasons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,9 +51,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -100,9 +109,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -118,9 +127,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -146,7 +155,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -156,10 +165,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -390,7 +397,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -406,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -484,15 +491,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -653,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -668,7 +674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -680,16 +686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,15 +693,21 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -715,9 +717,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "litemap"
@@ -747,6 +749,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,7 +765,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-session"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "axum",
  "futures-core",
@@ -764,6 +775,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -786,6 +799,15 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -829,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "percent-encoding"
@@ -911,7 +933,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -960,9 +982,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -976,7 +998,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1000,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1032,6 +1054,23 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1087,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.4.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64",
@@ -1118,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.4.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1137,9 +1176,9 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "ring",
@@ -1151,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1161,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1298,6 +1337,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
 dependencies = [
  "bytes",
  "futures-util",
@@ -1418,6 +1466,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,9 +1501,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -1523,20 +1580,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -1581,6 +1638,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1627,14 +1714,20 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "want"
@@ -1653,11 +1746,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1666,14 +1759,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1684,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1694,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1704,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1717,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -1760,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1780,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2012,6 +2105,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-session"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Bounded session management for MCP servers — max sessions, FIFO eviction, rate limiting"
@@ -11,7 +11,8 @@ rust-version = "1.88"
 
 [dependencies]
 rmcp = { version = "1.1", features = ["server", "transport-streamable-http-server"] }
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "rt", "time"] }
+tracing = "0.1"
 futures-core = { version = "0.3", default-features = false }
 thiserror = "2"
 
@@ -22,3 +23,4 @@ rmcp = { version = "1.1", features = ["server", "macros", "transport-streamable-
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 //! - **Optional rate limiting** on session creation via a sliding-window
 //!   counter.
 //! - **Idle timeout** via rmcp's `keep_alive` configuration (passed through).
+//! - **Optional max-lifetime enforcement** that closes sessions after a fixed
+//!   duration regardless of activity.
 //!
 //! # Quick start
 //!
@@ -26,10 +28,26 @@
 //!
 //! // Pass `manager` to `StreamableHttpService::new(factory, manager, config)`
 //! ```
+//!
+//! # Builder usage
+//!
+//! ```rust,no_run
+//! use std::time::Duration;
+//! use mcp_session::BoundedSessionManagerBuilder;
+//!
+//! let manager = BoundedSessionManagerBuilder::new(100)
+//!     .idle_timeout(Duration::from_secs(4 * 60 * 60))
+//!     .max_lifetime(Duration::from_secs(24 * 60 * 60))
+//!     .rate_limit(10, Duration::from_secs(60))
+//!     .build();
+//!
+//! // Pass `manager` to `StreamableHttpService::new(factory, manager, config)`
+//! ```
 
 #![warn(missing_docs)]
 
 use std::collections::VecDeque;
+use std::sync::Weak;
 use std::time::{Duration, Instant};
 
 use futures_core::Stream;
@@ -53,6 +71,7 @@ pub use rmcp::transport::streamable_http_server::session::SessionId;
 
 /// Errors returned by [`BoundedSessionManager`].
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum BoundedSessionError {
     /// Propagated from the inner [`LocalSessionManager`].
     #[error(transparent)]
@@ -60,6 +79,41 @@ pub enum BoundedSessionError {
     /// Session creation was rejected because the rate limit was exceeded.
     #[error("session creation rate limit exceeded")]
     RateLimited,
+}
+
+// ---------------------------------------------------------------------------
+// CloseReason
+// ---------------------------------------------------------------------------
+
+/// The reason a session was closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CloseReason {
+    /// The session was evicted to make room for a new one (FIFO).
+    Evicted,
+    /// The session exceeded its configured maximum lifetime.
+    MaxLifetime,
+    /// The session was closed explicitly.
+    Closed,
+}
+
+impl std::fmt::Display for CloseReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Evicted => f.write_str("Evicted"),
+            Self::MaxLifetime => f.write_str("MaxLifetime"),
+            Self::Closed => f.write_str("Closed"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal lifecycle tracking
+// ---------------------------------------------------------------------------
+
+struct SessionLifecycleEntry {
+    created_at: Instant,
+    abort_handle: Option<tokio::task::AbortHandle>,
 }
 
 // ---------------------------------------------------------------------------
@@ -129,12 +183,16 @@ impl RateLimiter {
 /// Optionally, a rate limit can be applied to session creation via
 /// [`BoundedSessionManager::with_rate_limit`].
 ///
+/// For max-lifetime enforcement and structured lifecycle logging, prefer
+/// constructing via [`BoundedSessionManagerBuilder`].
+///
 /// # Concurrency note
 ///
 /// Under concurrent session creation, the live count may transiently exceed
 /// `max_sessions` by at most the number of concurrent callers. The limit is
 /// best-effort under contention; use a semaphore if exact enforcement is
 /// required.
+#[non_exhaustive]
 pub struct BoundedSessionManager {
     inner: LocalSessionManager,
     max_sessions: usize,
@@ -142,6 +200,15 @@ pub struct BoundedSessionManager {
     creation_order: tokio::sync::Mutex<VecDeque<SessionId>>,
     /// Optional sliding-window rate limiter for session creation.
     rate_limiter: Option<RateLimiter>,
+    /// Optional maximum session lifetime. Sessions are closed after this
+    /// duration regardless of activity.
+    max_lifetime: Option<Duration>,
+    /// Per-session lifecycle entries (created_at + abort handle for the
+    /// max-lifetime timer task).
+    lifecycle: tokio::sync::RwLock<std::collections::HashMap<SessionId, SessionLifecycleEntry>>,
+    /// Weak self-reference, populated only when max_lifetime is Some so that
+    /// the timer task can call back into the manager.
+    self_ref: Option<Weak<Self>>,
 }
 
 impl BoundedSessionManager {
@@ -164,6 +231,9 @@ impl BoundedSessionManager {
             max_sessions,
             creation_order: tokio::sync::Mutex::new(VecDeque::new()),
             rate_limiter: None,
+            max_lifetime: None,
+            lifecycle: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+            self_ref: None,
         }
     }
 
@@ -185,6 +255,44 @@ impl BoundedSessionManager {
         );
         self.rate_limiter = Some(RateLimiter::new(max_creates, window));
         self
+    }
+
+    /// Returns the number of currently tracked live sessions.
+    pub async fn active_session_count(&self) -> usize {
+        self.lifecycle.read().await.len()
+    }
+
+    /// Unified close path: remove lifecycle entry, cancel timer, close inner
+    /// session, update creation order, and log with the given reason.
+    async fn close_session_impl(
+        &self,
+        id: &SessionId,
+        reason: CloseReason,
+    ) -> Result<(), BoundedSessionError> {
+        let entry = self.lifecycle.write().await.remove(id);
+        if let Some(ref e) = entry {
+            if let Some(ref handle) = e.abort_handle {
+                handle.abort();
+            }
+        }
+        let elapsed = entry.as_ref().map(|e| e.created_at.elapsed());
+
+        let close_result = self.inner.close_session(id).await;
+
+        let mut order = self.creation_order.lock().await;
+        order.retain(|s| s != id);
+        drop(order);
+
+        if let Some(elapsed) = elapsed {
+            tracing::info!(
+                session_id = %id,
+                duration_secs = elapsed.as_secs_f64(),
+                reason = %reason,
+                "session closed"
+            );
+        }
+
+        close_result.map_err(Into::into)
     }
 }
 
@@ -222,8 +330,7 @@ impl SessionManager for BoundedSessionManager {
         // Evict oldest (no lock held across this await).
         // ----------------------------------------------------------------
         if let Some(ref oldest) = evict_candidate {
-            // Ignore errors: the session may have already expired.
-            let _ = self.inner.close_session(oldest).await;
+            let _ = self.close_session_impl(oldest, CloseReason::Evicted).await;
         }
 
         // ----------------------------------------------------------------
@@ -261,14 +368,41 @@ impl SessionManager for BoundedSessionManager {
             order.push_back(id.clone());
         }
 
+        // ----------------------------------------------------------------
+        // Register lifecycle entry (and spawn max-lifetime timer if needed).
+        // ----------------------------------------------------------------
+        let abort_handle =
+            if let (Some(max_lifetime), Some(ref weak)) = (self.max_lifetime, &self.self_ref) {
+                let weak = weak.clone();
+                let timer_id = id.clone();
+                let handle = tokio::spawn(async move {
+                    tokio::time::sleep(max_lifetime).await;
+                    if let Some(arc) = weak.upgrade() {
+                        let _ = arc
+                            .close_session_impl(&timer_id, CloseReason::MaxLifetime)
+                            .await;
+                    }
+                });
+                Some(handle.abort_handle())
+            } else {
+                None
+            };
+
+        self.lifecycle.write().await.insert(
+            id.clone(),
+            SessionLifecycleEntry {
+                created_at: Instant::now(),
+                abort_handle,
+            },
+        );
+
+        tracing::info!(session_id = %id, "session created");
+
         Ok((id, transport))
     }
 
     async fn close_session(&self, id: &SessionId) -> Result<(), Self::Error> {
-        self.inner.close_session(id).await?;
-        let mut order = self.creation_order.lock().await;
-        order.retain(|s| s != id);
-        Ok(())
+        self.close_session_impl(id, CloseReason::Closed).await
     }
 
     async fn initialize_session(
@@ -327,5 +461,134 @@ impl SessionManager for BoundedSessionManager {
             .resume(id, last_event_id)
             .await
             .map_err(Into::into)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BoundedSessionManagerBuilder
+// ---------------------------------------------------------------------------
+
+/// Fluent builder for [`BoundedSessionManager`].
+///
+/// Prefer this over [`BoundedSessionManager::new`] when you need max-lifetime
+/// enforcement or want to configure idle timeouts without manually constructing
+/// a [`SessionConfig`].
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use std::time::Duration;
+/// use mcp_session::BoundedSessionManagerBuilder;
+///
+/// let manager = BoundedSessionManagerBuilder::new(100)
+///     .idle_timeout(Duration::from_secs(4 * 60 * 60))
+///     .max_lifetime(Duration::from_secs(24 * 60 * 60))
+///     .rate_limit(10, Duration::from_secs(60))
+///     .build();
+/// ```
+#[non_exhaustive]
+pub struct BoundedSessionManagerBuilder {
+    max_sessions: usize,
+    idle_timeout: Option<Duration>,
+    max_lifetime: Option<Duration>,
+    session_config: Option<SessionConfig>,
+    rate_limit: Option<(usize, Duration)>,
+}
+
+impl BoundedSessionManagerBuilder {
+    /// Create a new builder.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_sessions` is 0.
+    pub fn new(max_sessions: usize) -> Self {
+        assert!(max_sessions >= 1, "max_sessions must be at least 1, got 0");
+        Self {
+            max_sessions,
+            idle_timeout: None,
+            max_lifetime: None,
+            session_config: None,
+            rate_limit: None,
+        }
+    }
+
+    /// Set the idle timeout (maps to `SessionConfig::keep_alive`).
+    ///
+    /// If a `session_config` with `keep_alive` already set is also provided,
+    /// this value takes precedence and a warning is logged.
+    #[must_use]
+    pub fn idle_timeout(mut self, duration: Duration) -> Self {
+        self.idle_timeout = Some(duration);
+        self
+    }
+
+    /// Set a hard maximum lifetime for sessions.
+    ///
+    /// Sessions are closed after this duration regardless of activity. Requires
+    /// a Tokio runtime to be active when [`build`](Self::build) is called.
+    #[must_use]
+    pub fn max_lifetime(mut self, duration: Duration) -> Self {
+        self.max_lifetime = Some(duration);
+        self
+    }
+
+    /// Supply a fully constructed [`SessionConfig`].
+    ///
+    /// If [`idle_timeout`](Self::idle_timeout) is also set, it overrides
+    /// `keep_alive` in this config.
+    #[must_use]
+    pub fn session_config(mut self, config: SessionConfig) -> Self {
+        self.session_config = Some(config);
+        self
+    }
+
+    /// Configure a sliding-window rate limit on session creation.
+    ///
+    /// At most `max_creates` sessions may be created in any rolling `window`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_creates` is 0.
+    #[must_use]
+    pub fn rate_limit(mut self, max_creates: usize, window: Duration) -> Self {
+        assert!(
+            max_creates >= 1,
+            "max_creates must be at least 1; pass no rate limit instead of 0"
+        );
+        self.rate_limit = Some((max_creates, window));
+        self
+    }
+
+    /// Build the [`BoundedSessionManager`], returning an [`Arc`](std::sync::Arc).
+    pub fn build(self) -> std::sync::Arc<BoundedSessionManager> {
+        let explicit_config = self.session_config.is_some();
+        let mut session_config = self.session_config.unwrap_or_default();
+
+        if let Some(idle) = self.idle_timeout {
+            if explicit_config && session_config.keep_alive.is_some() {
+                tracing::warn!("idle_timeout overrides SessionConfig::keep_alive");
+            }
+            session_config.keep_alive = Some(idle);
+        }
+
+        let max_sessions = self.max_sessions;
+        let max_lifetime = self.max_lifetime;
+        let rate_limiter = self
+            .rate_limit
+            .map(|(max_creates, window)| RateLimiter::new(max_creates, window));
+
+        std::sync::Arc::new_cyclic(|weak| {
+            let mut inner = LocalSessionManager::default();
+            inner.session_config = session_config;
+            BoundedSessionManager {
+                inner,
+                max_sessions,
+                creation_order: tokio::sync::Mutex::new(VecDeque::new()),
+                rate_limiter,
+                max_lifetime,
+                lifecycle: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+                self_ref: Some(weak.clone()),
+            }
+        })
     }
 }

--- a/tests/session_lifecycle.rs
+++ b/tests/session_lifecycle.rs
@@ -1,0 +1,722 @@
+//! Integration tests for session lifecycle observability: builder API,
+//! max-lifetime enforcement, lifecycle tracing, and close reasons.
+//!
+//! Uses the same HTTP-level testing approach as `session_limits.rs`.
+//! Tracing assertions use an in-memory capturing layer installed as the
+//! global subscriber (one test per nextest process).
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::Router;
+use mcp_session::{
+    BoundedSessionManager, BoundedSessionManagerBuilder, CloseReason, SessionConfig,
+};
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use rmcp::ServerHandler;
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+use tracing::Subscriber;
+use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+
+// ---------------------------------------------------------------------------
+// Minimal MCP handler
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct NoopServer;
+impl ServerHandler for NoopServer {}
+
+// ---------------------------------------------------------------------------
+// Capturing tracing layer
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct EventRecord {
+    message: String,
+    fields: Vec<(String, String)>,
+}
+
+#[derive(Default)]
+struct RecordStore {
+    events: Vec<EventRecord>,
+}
+
+struct CapturingLayer {
+    store: Arc<Mutex<RecordStore>>,
+}
+
+impl<S: Subscriber> Layer<S> for CapturingLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let mut kv: Vec<(String, String)> = Vec::new();
+        let mut message = String::new();
+
+        struct Visitor<'a> {
+            kv: &'a mut Vec<(String, String)>,
+            message: &'a mut String,
+        }
+        impl tracing::field::Visit for Visitor<'_> {
+            fn record_debug(&mut self, field: &tracing::field::Field, val: &dyn std::fmt::Debug) {
+                let s = format!("{val:?}");
+                if field.name() == "message" {
+                    *self.message = s;
+                } else {
+                    self.kv.push((field.name().to_string(), s));
+                }
+            }
+            fn record_str(&mut self, field: &tracing::field::Field, val: &str) {
+                if field.name() == "message" {
+                    *self.message = val.to_string();
+                } else {
+                    self.kv.push((field.name().to_string(), val.to_string()));
+                }
+            }
+            fn record_f64(&mut self, field: &tracing::field::Field, val: f64) {
+                self.kv.push((field.name().to_string(), val.to_string()));
+            }
+        }
+
+        event.record(&mut Visitor {
+            kv: &mut kv,
+            message: &mut message,
+        });
+
+        self.store.lock().unwrap().events.push(EventRecord {
+            message,
+            fields: kv,
+        });
+    }
+}
+
+fn install_capturing() -> Arc<Mutex<RecordStore>> {
+    let store = Arc::new(Mutex::new(RecordStore::default()));
+    let subscriber = tracing_subscriber::registry().with(CapturingLayer {
+        store: Arc::clone(&store),
+    });
+    // set_global_default can only be called once per process; nextest gives
+    // us process-per-test isolation so this is safe.
+    let _ = tracing::subscriber::set_global_default(subscriber);
+    store
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+fn build_router_with_builder(manager: Arc<BoundedSessionManager>) -> (Router, CancellationToken) {
+    let ct = CancellationToken::new();
+    let ct_child = ct.child_token();
+
+    let service = StreamableHttpService::new(|| Ok(NoopServer), manager, {
+        let mut config = StreamableHttpServerConfig::default();
+        config.cancellation_token = ct_child;
+        config
+    });
+
+    let router = Router::new().nest_service("/mcp", service);
+    (router, ct)
+}
+
+async fn spawn_server_with_builder(
+    manager: Arc<BoundedSessionManager>,
+) -> (String, CancellationToken) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind to random port");
+    let addr = listener.local_addr().expect("get local addr");
+    let base_url = format!("http://{}", addr);
+
+    let (router, ct) = build_router_with_builder(manager);
+    let ct_child = ct.child_token();
+
+    tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(ct_child.cancelled_owned())
+            .await
+            .expect("server error");
+    });
+
+    (base_url, ct)
+}
+
+fn initialize_body() -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "0.1.0"}
+        }
+    })
+}
+
+fn tools_list_body() -> serde_json::Value {
+    serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+}
+
+async fn post_mcp(
+    client: &reqwest::Client,
+    base_url: &str,
+    session_id: Option<&str>,
+    body: &serde_json::Value,
+) -> (reqwest::StatusCode, Option<String>) {
+    let mut builder = client
+        .post(format!("{}/mcp", base_url))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .json(body);
+
+    if let Some(sid) = session_id {
+        builder = builder.header("Mcp-Session-Id", sid);
+    }
+
+    let resp = builder.send().await.expect("HTTP request succeeded");
+    let status = resp.status();
+    let returned_sid = resp
+        .headers()
+        .get("Mcp-Session-Id")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let _ = resp.text().await;
+    (status, returned_sid)
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn u01_close_reason_derives() {
+    let r = CloseReason::Evicted;
+    assert_eq!(r, CloseReason::Evicted);
+    assert_ne!(r, CloseReason::MaxLifetime);
+    assert_ne!(r, CloseReason::Closed);
+
+    assert_eq!(format!("{}", CloseReason::Evicted), "Evicted");
+    assert_eq!(format!("{}", CloseReason::MaxLifetime), "MaxLifetime");
+    assert_eq!(format!("{}", CloseReason::Closed), "Closed");
+
+    let _ = format!("{:?}", r);
+    let r2 = r;
+    assert_eq!(r, r2);
+}
+
+/// Builder idle_timeout actually controls session idle expiry. Set a 1s idle
+/// timeout via the builder and verify the session expires after inactivity.
+#[tokio::test]
+async fn u02_builder_idle_timeout_controls_expiry() {
+    let mgr = BoundedSessionManagerBuilder::new(10)
+        .idle_timeout(Duration::from_secs(1))
+        .build();
+
+    let (base_url, _ct) = spawn_server_with_builder(mgr).await;
+    let client = reqwest::Client::new();
+
+    let (status, sid) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(status.is_success());
+    let sid = sid.expect("session id");
+
+    // Session alive immediately after creation.
+    let (status, _) = post_mcp(&client, &base_url, Some(&sid), &tools_list_body()).await;
+    assert!(status.is_success(), "session should be alive");
+
+    // Wait for idle timeout.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Session should have expired.
+    let (status, _) = post_mcp(&client, &base_url, Some(&sid), &tools_list_body()).await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::NOT_FOUND,
+        "session should have expired via idle timeout"
+    );
+}
+
+/// Builder with passthrough SessionConfig that sets keep_alive — idle_timeout
+/// should override it.
+#[tokio::test]
+async fn u03_idle_timeout_overrides_passthrough_keep_alive() {
+    let mut cfg = SessionConfig::default();
+    cfg.keep_alive = Some(Duration::from_secs(300));
+
+    let mgr = BoundedSessionManagerBuilder::new(10)
+        .idle_timeout(Duration::from_secs(1))
+        .session_config(cfg)
+        .build();
+
+    let (base_url, _ct) = spawn_server_with_builder(mgr).await;
+    let client = reqwest::Client::new();
+
+    let (status, sid) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(status.is_success());
+    let sid = sid.expect("session id");
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // If idle_timeout (1s) didn't override keep_alive (300s), this would succeed.
+    let (status, _) = post_mcp(&client, &base_url, Some(&sid), &tools_list_body()).await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::NOT_FOUND,
+        "idle_timeout should override passthrough keep_alive"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests: Max lifetime
+// ---------------------------------------------------------------------------
+
+/// T-01: Max lifetime closes session after configured duration.
+#[tokio::test]
+async fn t01_max_lifetime_closes_session() {
+    let mgr = BoundedSessionManagerBuilder::new(10)
+        .idle_timeout(Duration::from_secs(300))
+        .max_lifetime(Duration::from_secs(2))
+        .build();
+
+    let (base_url, _ct) = spawn_server_with_builder(mgr.clone()).await;
+    let client = reqwest::Client::new();
+
+    let (status, sid) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(status.is_success(), "initialize failed: {status}");
+    let sid = sid.expect("must have session id");
+
+    let (status, _) = post_mcp(&client, &base_url, Some(&sid), &tools_list_body()).await;
+    assert!(status.is_success(), "session should be alive: {status}");
+
+    tokio::time::sleep(Duration::from_secs(4)).await;
+
+    let (status, _) = post_mcp(&client, &base_url, Some(&sid), &tools_list_body()).await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::NOT_FOUND,
+        "session should be closed by max lifetime: {status}"
+    );
+}
+
+/// T-02: Early close cancels max lifetime task — no double-close.
+#[tokio::test]
+async fn t02_early_close_cancels_max_lifetime() {
+    let mgr = BoundedSessionManagerBuilder::new(10)
+        .idle_timeout(Duration::from_secs(300))
+        .max_lifetime(Duration::from_secs(2))
+        .build();
+
+    let (base_url, _ct) = spawn_server_with_builder(mgr.clone()).await;
+    let client = reqwest::Client::new();
+
+    let (status, sid) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(status.is_success());
+    let sid = sid.expect("must have session id");
+
+    let resp = client
+        .delete(format!("{}/mcp", base_url))
+        .header("Mcp-Session-Id", &sid)
+        .send()
+        .await
+        .expect("delete request");
+    assert!(resp.status().is_success(), "DELETE should succeed");
+
+    tokio::time::sleep(Duration::from_secs(4)).await;
+    assert_eq!(mgr.active_session_count().await, 0);
+}
+
+/// T-03: Eviction closes with reason Evicted; surviving session gets MaxLifetime.
+#[tokio::test]
+async fn t03_eviction_with_max_lifetime() {
+    let mgr = BoundedSessionManagerBuilder::new(1)
+        .idle_timeout(Duration::from_secs(300))
+        .max_lifetime(Duration::from_secs(3))
+        .build();
+
+    let (base_url, _ct) = spawn_server_with_builder(mgr.clone()).await;
+    let client = reqwest::Client::new();
+
+    let (status, sid_a) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(status.is_success());
+    let sid_a = sid_a.expect("session A id");
+
+    let (status, sid_b) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(status.is_success());
+    let _sid_b = sid_b.expect("session B id");
+
+    let (status, _) = post_mcp(&client, &base_url, Some(&sid_a), &tools_list_body()).await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::NOT_FOUND,
+        "A should be evicted"
+    );
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    assert_eq!(mgr.active_session_count().await, 0);
+}
+
+/// T-04: Lifecycle tracing — "session created" and "session closed" events carry
+/// the expected structured fields. Also verifies reason=Closed for explicit close,
+/// reason=Evicted for eviction, and reason=MaxLifetime for max lifetime expiry.
+///
+/// Merged into a single test because `set_global_default` can only be called once
+/// per process, and nextest provides process-per-test isolation.
+#[tokio::test]
+async fn t04_lifecycle_tracing_events() {
+    let store = install_capturing();
+
+    // --- Part 1: explicit close → reason=Closed ---
+    let mgr = BoundedSessionManagerBuilder::new(10)
+        .idle_timeout(Duration::from_secs(300))
+        .build();
+
+    let (base_url, _ct) = spawn_server_with_builder(mgr).await;
+    let client = reqwest::Client::new();
+
+    let (status, sid) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(status.is_success());
+    let sid = sid.expect("session id");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    {
+        let events = store.lock().unwrap();
+        let created = events
+            .events
+            .iter()
+            .find(|e| e.message.contains("session created"));
+        assert!(created.is_some(), "expected 'session created' event");
+        assert!(
+            created
+                .unwrap()
+                .fields
+                .iter()
+                .any(|(k, _)| k == "session_id"),
+            "session created event missing session_id"
+        );
+    }
+
+    let resp = client
+        .delete(format!("{}/mcp", base_url))
+        .header("Mcp-Session-Id", &sid)
+        .send()
+        .await
+        .expect("delete request");
+    assert!(resp.status().is_success());
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    {
+        let events = store.lock().unwrap();
+        let closed = events
+            .events
+            .iter()
+            .find(|e| e.message.contains("session closed"));
+        assert!(closed.is_some(), "expected 'session closed' event");
+        let closed = closed.unwrap();
+        assert!(
+            closed.fields.iter().any(|(k, _)| k == "session_id"),
+            "missing session_id; fields: {:?}",
+            closed.fields
+        );
+        assert!(
+            closed.fields.iter().any(|(k, _)| k == "duration_secs"),
+            "missing duration_secs; fields: {:?}",
+            closed.fields
+        );
+        assert!(
+            closed
+                .fields
+                .iter()
+                .any(|(k, v)| k == "reason" && v == "Closed"),
+            "expected reason=Closed; fields: {:?}",
+            closed.fields
+        );
+    }
+
+    // --- Part 2: eviction → reason=Evicted ---
+    store.lock().unwrap().events.clear();
+
+    let mgr2 = BoundedSessionManagerBuilder::new(1)
+        .idle_timeout(Duration::from_secs(300))
+        .build();
+    let (base_url2, _ct2) = spawn_server_with_builder(mgr2).await;
+
+    let (status, _) = post_mcp(&client, &base_url2, None, &initialize_body()).await;
+    assert!(status.is_success());
+    let (status, _) = post_mcp(&client, &base_url2, None, &initialize_body()).await;
+    assert!(status.is_success());
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    {
+        let events = store.lock().unwrap();
+        let evicted = events.events.iter().find(|e| {
+            e.message.contains("session closed")
+                && e.fields
+                    .iter()
+                    .any(|(k, v)| k == "reason" && v == "Evicted")
+        });
+        assert!(
+            evicted.is_some(),
+            "expected 'session closed' with reason=Evicted; events: {:?}",
+            events
+                .events
+                .iter()
+                .filter(|e| e.message.contains("session closed"))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    // --- Part 3: max lifetime → reason=MaxLifetime ---
+    store.lock().unwrap().events.clear();
+
+    let mgr3 = BoundedSessionManagerBuilder::new(10)
+        .idle_timeout(Duration::from_secs(300))
+        .max_lifetime(Duration::from_secs(1))
+        .build();
+    let (base_url3, _ct3) = spawn_server_with_builder(mgr3).await;
+
+    let (status, _) = post_mcp(&client, &base_url3, None, &initialize_body()).await;
+    assert!(status.is_success());
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    {
+        let events = store.lock().unwrap();
+        let max_lt = events.events.iter().find(|e| {
+            e.message.contains("session closed")
+                && e.fields
+                    .iter()
+                    .any(|(k, v)| k == "reason" && v == "MaxLifetime")
+        });
+        assert!(
+            max_lt.is_some(),
+            "expected 'session closed' with reason=MaxLifetime; events: {:?}",
+            events
+                .events
+                .iter()
+                .filter(|e| e.message.contains("session closed"))
+                .collect::<Vec<_>>()
+        );
+    }
+}
+
+/// T-06: Backward compat — new() API works without lifecycle tracking.
+#[tokio::test]
+async fn t06_backward_compat_new_api() {
+    let mut cfg = SessionConfig::default();
+    cfg.keep_alive = Some(Duration::from_secs(300));
+
+    let mgr = Arc::new(BoundedSessionManager::new(cfg, 10));
+
+    let ct = CancellationToken::new();
+    let ct_child = ct.child_token();
+
+    let service = StreamableHttpService::new(|| Ok(NoopServer), mgr, {
+        let mut config = StreamableHttpServerConfig::default();
+        config.cancellation_token = ct_child;
+        config
+    });
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let base_url = format!("http://{}", addr);
+
+    tokio::spawn(async move {
+        axum::serve(listener, Router::new().nest_service("/mcp", service))
+            .with_graceful_shutdown(ct.child_token().cancelled_owned())
+            .await
+            .expect("server");
+    });
+
+    let client = reqwest::Client::new();
+    let (status, sid) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(status.is_success(), "new() API should work: {status}");
+    let sid = sid.expect("session id");
+
+    let (status, _) = post_mcp(&client, &base_url, Some(&sid), &tools_list_body()).await;
+    assert!(status.is_success(), "session should be active: {status}");
+}
+
+/// T-07: Builder with only rate_limit — no lifecycle tasks spawned.
+#[tokio::test]
+async fn t07_builder_rate_limit_only() {
+    let mgr = BoundedSessionManagerBuilder::new(10)
+        .rate_limit(2, Duration::from_secs(60))
+        .build();
+
+    let (base_url, _ct) = spawn_server_with_builder(mgr).await;
+    let client = reqwest::Client::new();
+
+    let (status, _) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(status.is_success(), "first session should succeed");
+
+    let (status, _) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(status.is_success(), "second session should succeed");
+
+    let (status, _) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(!status.is_success(), "third session should be rate limited");
+}
+
+/// T-08: Multiple sessions with max lifetime all close correctly.
+#[tokio::test]
+async fn t08_multiple_sessions_max_lifetime() {
+    let mgr = BoundedSessionManagerBuilder::new(10)
+        .idle_timeout(Duration::from_secs(300))
+        .max_lifetime(Duration::from_secs(2))
+        .build();
+
+    let (base_url, _ct) = spawn_server_with_builder(mgr.clone()).await;
+    let client = reqwest::Client::new();
+
+    let mut sids = Vec::new();
+    for _ in 0..5 {
+        let (status, sid) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+        assert!(status.is_success());
+        sids.push(sid.expect("session id"));
+    }
+
+    assert_eq!(mgr.active_session_count().await, 5);
+
+    tokio::time::sleep(Duration::from_secs(4)).await;
+
+    assert_eq!(mgr.active_session_count().await, 0);
+
+    for sid in &sids {
+        let (status, _) = post_mcp(&client, &base_url, Some(sid), &tools_list_body()).await;
+        assert_eq!(status, reqwest::StatusCode::NOT_FOUND);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Invariant tests
+// ---------------------------------------------------------------------------
+
+/// I-01: Lifecycle map has exactly one entry per live session.
+#[tokio::test]
+async fn i01_lifecycle_map_matches_live_sessions() {
+    let mgr = BoundedSessionManagerBuilder::new(10)
+        .idle_timeout(Duration::from_secs(300))
+        .build();
+
+    let (base_url, _ct) = spawn_server_with_builder(mgr.clone()).await;
+    let client = reqwest::Client::new();
+
+    let mut sids = Vec::new();
+    for _ in 0..5 {
+        let (status, sid) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+        assert!(status.is_success());
+        sids.push(sid.expect("session id"));
+    }
+    assert_eq!(mgr.active_session_count().await, 5);
+
+    for sid in &sids[..2] {
+        let resp = client
+            .delete(format!("{}/mcp", base_url))
+            .header("Mcp-Session-Id", sid)
+            .send()
+            .await
+            .expect("delete");
+        assert!(resp.status().is_success());
+    }
+    assert_eq!(mgr.active_session_count().await, 3);
+
+    for sid in &sids[2..] {
+        let resp = client
+            .delete(format!("{}/mcp", base_url))
+            .header("Mcp-Session-Id", sid)
+            .send()
+            .await
+            .expect("delete");
+        assert!(resp.status().is_success());
+    }
+    assert_eq!(mgr.active_session_count().await, 0);
+}
+
+/// I-02: No leaked abort handles after all sessions close.
+#[tokio::test]
+async fn i02_no_leaked_abort_handles() {
+    let mgr = BoundedSessionManagerBuilder::new(10)
+        .idle_timeout(Duration::from_secs(300))
+        .max_lifetime(Duration::from_secs(60))
+        .build();
+
+    let (base_url, _ct) = spawn_server_with_builder(mgr.clone()).await;
+    let client = reqwest::Client::new();
+
+    let mut sids = Vec::new();
+    for _ in 0..3 {
+        let (status, sid) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+        assert!(status.is_success());
+        sids.push(sid.expect("session id"));
+    }
+
+    for sid in &sids {
+        let resp = client
+            .delete(format!("{}/mcp", base_url))
+            .header("Mcp-Session-Id", sid)
+            .send()
+            .await
+            .expect("delete");
+        assert!(resp.status().is_success());
+    }
+
+    assert_eq!(mgr.active_session_count().await, 0);
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    assert_eq!(mgr.active_session_count().await, 0);
+}
+
+/// I-03: Eviction + timeout don't corrupt state.
+#[tokio::test]
+async fn i03_eviction_and_timeout_no_corruption() {
+    let mgr = BoundedSessionManagerBuilder::new(2)
+        .idle_timeout(Duration::from_secs(300))
+        .max_lifetime(Duration::from_secs(3))
+        .build();
+
+    let (base_url, _ct) = spawn_server_with_builder(mgr.clone()).await;
+    let client = reqwest::Client::new();
+
+    let (status, sid_a) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(status.is_success(), "A create failed");
+    let sid_a = sid_a.expect("A");
+    let (status, _) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(status.is_success(), "B create failed");
+
+    // C evicts A, D evicts B.
+    let (status, sid_c) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(status.is_success(), "C create failed");
+    let sid_c = sid_c.expect("C");
+    let (status, sid_d) = post_mcp(&client, &base_url, None, &initialize_body()).await;
+    assert!(status.is_success(), "D create failed");
+    let sid_d = sid_d.expect("D");
+
+    // A should be evicted.
+    let (status, _) = post_mcp(&client, &base_url, Some(&sid_a), &tools_list_body()).await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::NOT_FOUND,
+        "A should be evicted"
+    );
+
+    // C and D should be alive.
+    assert_eq!(mgr.active_session_count().await, 2);
+
+    // Wait for max lifetime to close C and D.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    assert_eq!(mgr.active_session_count().await, 0);
+
+    // C and D should be gone.
+    let (status, _) = post_mcp(&client, &base_url, Some(&sid_c), &tools_list_body()).await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::NOT_FOUND,
+        "C should be expired"
+    );
+    let (status, _) = post_mcp(&client, &base_url, Some(&sid_d), &tools_list_body()).await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::NOT_FOUND,
+        "D should be expired"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `BoundedSessionManagerBuilder` with `.idle_timeout()`, `.max_lifetime()`, `.rate_limit()`, and `.session_config()` for fluent session management configuration
- Max lifetime enforcement via one-shot per-session tokio task with `AbortHandle` cleanup — sessions are closed after a fixed duration regardless of activity
- Structured tracing events on session create/close with `session_id`, `duration_secs`, and `CloseReason` (`Evicted`, `MaxLifetime`, `Closed`)
- Unified close path via `close_session_impl(id, reason)` — lock-free reason propagation, no mutex
- `#[non_exhaustive]` on `BoundedSessionError`, `BoundedSessionManager`, `CloseReason`, `BoundedSessionManagerBuilder`
- Backward compatible: existing `BoundedSessionManager::new()` + `.with_rate_limit()` API unchanged
- Version bump: 0.1.3 → 0.2.0

## Design

- Idle timeout delegates to rmcp's event-loop timer via `SessionConfig::keep_alive` — zero overhead, no reimplementation
- Max lifetime is a one-shot `tokio::spawn(sleep(duration))` per session, cancelled via `AbortHandle` in the unified close path
- Builder absorbs `keep_alive` to prevent two-knob conflict: if both `.idle_timeout()` and passthrough `SessionConfig::keep_alive` are set, the builder overrides with a warning
- Close reason flows as a `Copy` parameter through `close_session_impl` — no shared state, no lock

## Test plan

- 13 new integration tests covering builder API, max lifetime expiry, early close cancellation, eviction + max lifetime interaction, lifecycle tracing event capture, backward compat, rate limiting
- Tracing tests use an in-memory `CapturingLayer` and assert on `session_id`, `duration_secs`, and `reason` fields for all three `CloseReason` variants

Closes butterflyskies/memory-mcp#114

🤖 Generated with [Claude Code](https://claude.com/claude-code)