### PR TITLE
chore: strip #[non_exhaustive] per org ban (ADR-0040)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,6 @@ pub use rmcp::transport::streamable_http_server::session::SessionId;
 
 /// Errors returned by [`BoundedSessionManager`].
 #[derive(Debug, thiserror::Error)]
-#[non_exhaustive]
 pub enum BoundedSessionError {
     /// Propagated from the inner [`LocalSessionManager`].
     #[error(transparent)]
@@ -87,7 +86,6 @@ pub enum BoundedSessionError {
 
 /// The reason a session was closed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum CloseReason {
     /// The session was evicted to make room for a new one (FIFO).
     Evicted,
@@ -192,7 +190,6 @@ impl RateLimiter {
 /// `max_sessions` by at most the number of concurrent callers. The limit is
 /// best-effort under contention; use a semaphore if exact enforcement is
 /// required.
-#[non_exhaustive]
 pub struct BoundedSessionManager {
     inner: LocalSessionManager,
     max_sessions: usize,
@@ -486,7 +483,6 @@ impl SessionManager for BoundedSessionManager {
 ///     .rate_limit(10, Duration::from_secs(60))
 ///     .build();
 /// ```
-#[non_exhaustive]
 pub struct BoundedSessionManagerBuilder {
     max_sessions: usize,
     idle_timeout: Option<Duration>,


### PR DESCRIPTION
## Summary
- Removes all 4 `#[non_exhaustive]` attributes from `src/lib.rs` per ADR-0040
- Sites: `BoundedSessionError`, `CloseReason`, `BoundedSessionManager`, `BoundedSessionManagerBuilder`
- `cargo check` clean, 13/14 tests pass (1 pre-existing timing flake in `t05b_idle_timeout_lifecycle_cleanup`)

Closes #26

## Test plan
- [x] `cargo check` — clean
- [x] `cargo test` — 13 pass, 1 pre-existing flake (confirmed same failure on main)
- [x] `grep -c non_exhaustive src/lib.rs` → 0