### PR TITLE
ci: add changelog gate

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,31 @@
+name: Changelog
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  check:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - name: Require CHANGELOG.md update when src/ changes
+        run: |
+          changed=$(git diff --name-only origin/main...HEAD)
+          if echo "$changed" | grep -q '^src/'; then
+            if echo "$changed" | grep -q '^CHANGELOG.md$'; then
+              echo "✅ src/ changed and CHANGELOG.md updated."
+            else
+              echo "::error::This PR modifies src/ but doesn't update CHANGELOG.md. Add a changelog entry under [Unreleased] or apply the 'skip-changelog' label."
+              exit 1
+            fi
+          else
+            echo "✅ No src/ changes — changelog not required."
+          fi


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that requires CHANGELOG.md to be updated when src/ changes
- PRs can skip this check by applying the `skip-changelog` label
- Pattern adapted from dione PR #244

## Test plan

- [ ] Open a PR that modifies src/ without updating CHANGELOG.md — check should fail
- [ ] Open a PR that modifies src/ with a CHANGELOG.md update — check should pass
- [ ] Open a PR that only modifies non-src/ files — check should pass
- [ ] Apply `skip-changelog` label — check should be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)